### PR TITLE
Fix `make server` Command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ scripts: $(ELM_FILES)
 	elm-make $(ELM_ENTRY) --yes --warn --output $(BUILD_DIR)/scripts/search.js
 
 html:
-	mkdir -p $(BUILD_DIR) && cp -r src/html/ $(BUILD_DIR)
+	mkdir -p $(BUILD_DIR) && cp -r src/html/* $(BUILD_DIR)
 
 # TODO: find a nice way to keep this DRY and dynamic
 cache/packages-017:


### PR DESCRIPTION
While trying to get a local serve running, I also ran into issues with the `make server` command. The `index.html` file was being served at `/html/index.html`. This caused the application to expect the styles and scripts at `/html/styles` and `/html/scripts`.

This PR fixes this by modify `make html` so that it copies index.html directly to `dist` instead of `dist/html`. 

I'm not sure if this messes with your deployment structure. If so, it might be better to specify the script, style, and index URLs in `index.html` as absolute paths instead of relative paths.
