### PR TITLE
Show Last Search Query and No Results Message

### DIFF
--- a/src/scripts/Search/Model.elm
+++ b/src/scripts/Search/Model.elm
@@ -22,6 +22,7 @@ type alias Index =
 type alias Filter =
     { queryString : String
     , query : List Query
+    , lastQuery : String
     }
 
 
@@ -55,6 +56,7 @@ initialFilter : Filter
 initialFilter =
     { queryString = ""
     , query = []
+    , lastQuery = ""
     }
 
 

--- a/src/scripts/Search/Update.elm
+++ b/src/scripts/Search/Update.elm
@@ -41,16 +41,9 @@ update msg model =
                         | queryString = queryString
                         , query = queryListFromString queryString
                     }
-
-                resultChunks =
-                    if String.isEmpty queryString then
-                        []
-                    else
-                        model.result.chunks
             in
                 { model
                     | filter = filter
-                    , result = { chunks = resultChunks }
                 }
 
         SetFilterQueryStringAndRunFilter queryString ->
@@ -58,4 +51,11 @@ update msg model =
                 |> update RunFilter
 
         RunFilter ->
-            { model | result = runFilter model.filter model.index }
+            let
+                newFilter filter =
+                    { filter | lastQuery = model.filter.queryString }
+            in
+                { model
+                    | result = runFilter model.filter model.index
+                    , filter = newFilter model.filter
+                }

--- a/src/scripts/Search/View.elm
+++ b/src/scripts/Search/View.elm
@@ -68,7 +68,7 @@ viewSearchBody : Model -> Html Msg
 viewSearchBody model =
     let
         searchBody =
-            if String.isEmpty model.filter.queryString then
+            if String.isEmpty model.filter.lastQuery then
                 viewSearchIntro
             else
                 viewSearchResults model
@@ -105,9 +105,22 @@ viewSearchIntro =
 
 
 viewSearchResults : Model -> Html Msg
-viewSearchResults { result } =
-    div [ class "searchResult" ]
-        (List.map viewChunk result.chunks)
+viewSearchResults { filter, result } =
+    let
+        viewQuery =
+            div [ class "searchQuery" ]
+                [ text <| "Showing results for: "
+                , b [] [ text filter.lastQuery ]
+                ]
+
+        viewChunks =
+            if not <| List.isEmpty result.chunks then
+                List.map viewChunk result.chunks
+            else
+                [ p [] [ text "No Results Found." ] ]
+    in
+        div [ class "searchResult" ]
+            (viewQuery :: viewChunks)
 
 
 viewChunk : Chunk -> Html Msg

--- a/src/scripts/Web/Model.elm
+++ b/src/scripts/Web/Model.elm
@@ -70,6 +70,7 @@ parseSearchString searchString =
             in
                 { queryString = queryString
                 , query = query
+                , lastQuery = ""
                 }
 
         _ ->

--- a/src/styles/search.css
+++ b/src/styles/search.css
@@ -117,6 +117,12 @@ code {
     font-weight: normal;
 }
 
+.searchQuery {
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-bottom: 1rem;
+}
+
 .searchChunk {
     width: 100%;
     margin: 0 auto 1.5rem auto;


### PR DESCRIPTION
Modify the Search Results view so that the query that was last searched
is displayed and that a message is displayed if there are no results.

The Search Introdution is only shown if the User has not search
anything, or their last search was blank.

Closes #3 and #4 
