### PR TITLE
Remove unnecessary disabled scrollbar

### DIFF
--- a/src/styles/search.css
+++ b/src/styles/search.css
@@ -142,7 +142,7 @@ code {
     margin: 0;
     padding: 0 1rem 1rem 1rem;
     overflow-y: hidden;
-    overflow-x: scroll;
+    overflow-x: auto;
     -webkit-overflow-scrolling: touch;
 }
 .chunkAnnotation a {


### PR DESCRIPTION
Using `overflow-x: auto;` instead of `overflow-x: scroll;` means that the scrollbar will only appear if a scrollbar is neeeded.

**Before:**
![Screenshot from 2019-05-13 17-40-18](https://user-images.githubusercontent.com/2142817/57634928-85200580-75a6-11e9-951b-ba372ecaaf5c.png)

**After:**
![Screenshot from 2019-05-13 17-40-33](https://user-images.githubusercontent.com/2142817/57634953-8f420400-75a6-11e9-9320-241667d4b1b9.png)
